### PR TITLE
fix: RuntimeError: unsupported version of sqlite3

### DIFF
--- a/streamlit/app/irisChatGPT.py
+++ b/streamlit/app/irisChatGPT.py
@@ -14,6 +14,10 @@ from langchain_experimental.sql import SQLDatabaseChain
 from langchain.prompts.prompt import PromptTemplate
 import os
 
+__import__('pysqlite3')
+import sys
+sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')
+
 MODEL = "gpt-3.5-turbo-0613"
 K = 10
 

--- a/streamlit/app/requirements.txt
+++ b/streamlit/app/requirements.txt
@@ -6,4 +6,5 @@ openai
 tiktoken
 faiss-cpu
 langchain-experimental
+pysqlite3-binary
 


### PR DESCRIPTION
streamlit web shows the below runtime error after I enter openai api key. so I follow https://docs.trychroma.com/troubleshooting#sqlite step to fix it.
![image](https://github.com/mwaseem75/irisChatGPT/assets/25856300/8eb5c5f9-a7da-40bf-8b72-31ec1ac1850e)
